### PR TITLE
Hair length calculation uses "middle" not "medium"

### DIFF
--- a/camelcalculator.js
+++ b/camelcalculator.js
@@ -75,7 +75,7 @@ class CamelCalculator{
             return 8;
           case "short":
             return 7;
-          case "medium":
+          case "middle":
             return 5;
           case "bald":
             return 2;


### PR DESCRIPTION
The UI was passing in "medium" while the calculation only recognizes "middle", hence an error was thrown. (Working on extracting unit tests from comments, adding more tests, and incorporating CI into github such as with Travis CI)